### PR TITLE
Change import statement for mouse_session schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,24 @@
-# DataJoint interactive tutorial
-Getting started materials for DataJoint - with Calcium Imaging, Electrophysiology, Machine Learning examples
+# DataJoint interactive tutorial using GitHub Codespaces
+
+### This README is the guide to setting up an interactive tutorial on DataJoint basics using GitHub Codespaces. Please follow the steps below for the best experience:
+
+1. Fork this repository to your own GitHub account.
+
+2. Click on the green `Code` button where you would typically click to clone a repository.
+
+3. Within the dropdown menu, click on the `Codespaces` tab.
+
+4. If this is your first time using Codespaces with this repository, please click on the green `Create codespace on master` button.
+
+5. Wait for the environment to be created. This step takes ~ 5 minutes. You will know the environment is ready when a Visual Studio Code window is rendered within your browser. If you are new to Visual Studio Code, please take a minute to familiarize yourself with the layout. The directories you will need to navigate are on the left side of the screen by default.
+
+6. Navigate to the 00-Getting_started directory and open the `00-Getting started.ipynb` Jupyter Notebook. Execute the cells in this notebook to being your walk through the tutorials.
+
+We recommend finishing all notebooks in `Getting_started` before proceeding to `Calcium_imaging` and `Electrophysiology`. Once you are done, GitHub will automatically terminate the Codespace after 30 minutes of inactivity or you can manually terminate the Codespace.
+
+If you are new to GitHub and run into any errors, please contact us via email. If you are experienced with GitHub, please create an issue on the upstream repository or issue a pull request with a thorough explanantion of the error and proposed solution. 
+
+**Please Note:** 
+
+```GitHub Codespaces are limited to 120 hours per month for free users. Once you exceed this limit, you will have to wait for the hours to reset or pay to use Codespaces.```
 

--- a/tutorial_pipeline/ephys_cell_activity.py
+++ b/tutorial_pipeline/ephys_cell_activity.py
@@ -3,7 +3,7 @@ import numpy as np
 import pathlib
 
 # import the mouse-session schema
-from tutorial_pipeline.mouse_session import schema, Mouse, Session
+from mouse_session import schema, Mouse, Session
 
 ephys_data_dir = pathlib.Path(__file__).parent.parent
 ephys_data_dir = ephys_data_dir / 'electrophysiology' / 'data'

--- a/tutorial_pipeline/imaging.py
+++ b/tutorial_pipeline/imaging.py
@@ -4,7 +4,7 @@ import os
 from skimage import io
 
 # import the mouse-session schema
-from tutorial_pipeline.mouse_session import schema, Mouse, Session
+from mouse_session import schema, Mouse, Session
 
 
 # Table definitions


### PR DESCRIPTION
This PR fixes a missing module error in the GitHub codespaces environment when going through the tutorials